### PR TITLE
🚑 chartConfigの取得時にseriesとdataの状態が不一致になりエラーが発生していたのを修正

### DIFF
--- a/components/parts/series-config-card.component.tsx
+++ b/components/parts/series-config-card.component.tsx
@@ -161,6 +161,7 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
                       onValueChange={(v: ObjectClassAttribute) =>
                         notify(updateSeriesProperty(["focusedAttribute", v], series))
                       }
+                      defaultValue={series.focusedAttribute}
                     >
                       <SelectTrigger
                         className={cn(

--- a/components/parts/series-config-card.component.tsx
+++ b/components/parts/series-config-card.component.tsx
@@ -30,6 +30,7 @@ import {
   SERIES_PROPERTY_EFFECT_TO,
 } from "@/interfaces/graph-series.interface";
 import { MouseEventHandler } from "react";
+import { cn } from "@/lib/utils";
 
 interface Props {
   series: GraphSeries;
@@ -89,8 +90,12 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
           onValueChange={(v: Placement) => notify(updateSeriesProperty(["placement", v], series))}
           defaultValue={series.placement}
         >
-          <SelectTrigger>
-            <SelectValue placeholder="AIカメラの設置場所" />
+          <SelectTrigger
+            className={cn(
+              `${series.placement !== undefined ? "text-foreground" : "text-gray-500"}`,
+            )}
+          >
+            <SelectValue placeholder="選択して下さい" />
           </SelectTrigger>
           <SelectContent>
             {Object.entries(PLACEMENTS).map(([placement, { text }]) => (
@@ -112,8 +117,12 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
             notify(updateSeriesProperty(["objectClass", v], series))
           }
         >
-          <SelectTrigger>
-            <SelectValue placeholder="AIカメラの検出対象" />
+          <SelectTrigger
+            className={cn(
+              `${series.objectClass !== undefined ? "text-foreground" : "text-gray-500"}`,
+            )}
+          >
+            <SelectValue placeholder="選択して下さい" />
           </SelectTrigger>
           <SelectContent>
             {series.placement
@@ -153,8 +162,12 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
                         notify(updateSeriesProperty(["focusedAttribute", v], series))
                       }
                     >
-                      <SelectTrigger className="mt-2">
-                        <SelectValue placeholder={graphTypeText + "に使う属性"} />
+                      <SelectTrigger
+                        className={cn(
+                          `${series.focusedAttribute !== undefined ? "text-foreground" : "text-gray-500"} mt-2`,
+                        )}
+                      >
+                        <SelectValue placeholder={"属性を選択して下さい"} />
                       </SelectTrigger>
                       <SelectContent>
                         {Object.keys(OBJECT_CLASS_ATTRIBUTES[series.objectClass]).map(


### PR DESCRIPTION
## 概要

系統の設定を変更したときに、系統の内容とデータの内容が別々のstateで管理されており、`getChartConfig`の呼び出し時に意図していない状態になりエラーになっていたのを修正しました。
また、セレクトボックスの見た目を改善し、選択が必要であることをわかりやすくしました。

## 再現方法

1. 積み上げ棒グラフ or 100%積み上げ棒グラフでグラフを表示する
2. 積み上げる属性を変更して再度表示しようとするとエラーになる