### PR TITLE
🚑ラジオボタンのラベルを選択した時のバグを修正

### DIFF
--- a/src/components/parts/series-config-card.component.tsx
+++ b/src/components/parts/series-config-card.component.tsx
@@ -180,8 +180,8 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
               {Object.entries(GRAPH_TYPES).map(([graphType, graphTypeText]) => (
                 <div key={graphType + "radio"}>
                   <div className="flex items-center space-x-2">
-                    <RadioGroupItem value={graphType} id={graphType} />
-                    <Label htmlFor={graphType}>{graphTypeText}</Label>
+                    <RadioGroupItem value={graphType} id={`${series.id}-${graphType}`} />
+                    <Label htmlFor={`${series.id}-${graphType}`}>{graphTypeText}</Label>
                   </div>
                   {graphType !== "simple" &&
                   graphType === series.graphType &&


### PR DESCRIPTION
ラジオボタンにユニークなIDを付与することで、グラフが複数ある場合に、1つ目のグラフだけに反映されてしまうバグを修正しました。