### PR TITLE
👍シリーズ設定カードの表示順を逆に変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,14 +242,16 @@ export default function App() {
             </Button>
           </div>
           <div className="flex w-full flex-col gap-y-2 px-1">
-            {Object.entries(seriesAll).map(([id, series]) => (
-              <SeriesConfigCard
-                key={id}
-                series={series}
-                notify={(nextSeries) => setSeries(nextSeries)}
-                onRemoveClick={() => onClickRemoveSeries(id)}
-              />
-            ))}
+            {Object.entries(seriesAll)
+              .reverse()
+              .map(([id, series]) => (
+                <SeriesConfigCard
+                  key={id}
+                  series={series}
+                  notify={(nextSeries) => setSeries(nextSeries)}
+                  onRemoveClick={() => onClickRemoveSeries(id)}
+                />
+              ))}
           </div>
         </section>
       </aside>


### PR DESCRIPTION
プラスボタンを押して系統を追加すると、一番下に追加され、系統が追加されたことに気づきにくいし、下までスクロールする必要が出てくるので、表示順を逆にしました。