### PR TITLE
👍Y軸に小数点が表示されないようにした

### DIFF
--- a/src/components/parts/graph.component.tsx
+++ b/src/components/parts/graph.component.tsx
@@ -140,7 +140,7 @@ export function Graph({ chartGroup, seriesAll, className }: Props) {
                       <CustomizedXAxisTick {...props} data={chartGroup[chartId]} />
                     )}
                   />
-                  <YAxis type="number" tickLine={true} tickCount={10} />
+                  <YAxis type="number" tickLine={true} tickCount={10} allowDecimals={false} />
                   {Object.keys(chartGroup[chartId].at(-1) ?? {})
                     .filter((key) => key !== "date" && key !== "holidayName" && key !== "dayOfWeek")
                     .map((key) => [key, ...key.split("#")])


### PR DESCRIPTION
左：修正前　右：修正後

<img width="200" alt="スクリーンショット 2025-06-10 16 36 08" src="https://github.com/user-attachments/assets/cb4be1a3-f7a7-42df-a1e1-67177b837cc4" />
<img width="200" alt="スクリーンショット 2025-06-10 16 36 26" src="https://github.com/user-attachments/assets/f3c3a3cc-cecf-421b-b3f3-1182e3646925" />
