### PR TITLE
🚑棒グラフをホバーした時のツールチップが円グラフの裏に隠れるのを修正

### DIFF
--- a/src/components/parts/graph.component.tsx
+++ b/src/components/parts/graph.component.tsx
@@ -170,6 +170,7 @@ export function Graph({ chartGroup, seriesAll, className }: Props) {
                   <ChartTooltip
                     cursor={{ fillOpacity: 0.4, stroke: "hsl(var(--primary))" }}
                     content={<ChartTooltipContent className="bg-white" />}
+                    wrapperStyle={{ zIndex: 100 }}
                   />
                   {Object.keys(chartGroup[chartId][0]).length <= 10 ? (
                     <ChartLegend content={<ChartLegendContent />} />
@@ -194,6 +195,7 @@ export function Graph({ chartGroup, seriesAll, className }: Props) {
                   <ChartTooltip
                     cursor={{ fillOpacity: 0.4, stroke: "hsl(var(--primary))" }}
                     content={<ChartTooltipContent className="bg-white" />}
+                    wrapperStyle={{ zIndex: 100 }}
                   />
                   {Object.keys(chartGroup[chartId]).length <= 10 ? (
                     <ChartLegend content={<ChartLegendContent />} />

--- a/src/components/parts/graph.component.tsx
+++ b/src/components/parts/graph.component.tsx
@@ -170,7 +170,7 @@ export function Graph({ chartGroup, seriesAll, className }: Props) {
                   <ChartTooltip
                     cursor={{ fillOpacity: 0.4, stroke: "hsl(var(--primary))" }}
                     content={<ChartTooltipContent className="bg-white" />}
-                    wrapperStyle={{ zIndex: 100 }}
+                    wrapperStyle={{ zIndex: "var(--tooltip-z-index)" }}
                   />
                   {Object.keys(chartGroup[chartId][0]).length <= 10 ? (
                     <ChartLegend content={<ChartLegendContent />} />
@@ -195,7 +195,7 @@ export function Graph({ chartGroup, seriesAll, className }: Props) {
                   <ChartTooltip
                     cursor={{ fillOpacity: 0.4, stroke: "hsl(var(--primary))" }}
                     content={<ChartTooltipContent className="bg-white" />}
-                    wrapperStyle={{ zIndex: 100 }}
+                    wrapperStyle={{ zIndex: "var(--tooltip-z-index)" }}
                   />
                   {Object.keys(chartGroup[chartId]).length <= 10 ? (
                     <ChartLegend content={<ChartLegendContent />} />

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,7 @@ body {
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
     --star: 42 75% 53%;
+    --tooltip-z-index: 1;
   }
   .dark {
     --background: 0 0% 3.9%;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,6 +73,9 @@ export default {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      zIndex: {
+        tooltip: "var(--tooltip-z-index)",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
<img width="200" alt="スクリーンショット 2025-06-10 16 31 58" src="https://github.com/user-attachments/assets/62373348-63bb-49ea-b189-7feb8b7cd5d8" />
