### PR TITLE
🚑 積み上げ棒グラフ等を選択した状態で検出対象を変更した時に、ラジオボタンが単純棒グラフに選択されるよう変更

### DIFF
--- a/src/components/parts/series-config-card.component.tsx
+++ b/src/components/parts/series-config-card.component.tsx
@@ -68,6 +68,21 @@ function updateSeriesProperty<Key extends keyof GraphSeries>(
 }
 
 export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
+  const handleGraphTypeChange = (selectedGraphType: GraphType) => {
+    if (selectedGraphType === "simple") {
+      notify({
+        ...series,
+        graphType: selectedGraphType,
+        focusedAttribute: undefined,
+      });
+    } else {
+      notify({
+        ...series,
+        graphType: selectedGraphType,
+      });
+    }
+  };
+
   return (
     <Card className="flex w-full flex-col gap-y-4 p-4">
       <div className="flex justify-between">
@@ -175,9 +190,7 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
             <span>グラフ種類</span>
             <RadioGroup
               value={series.graphType}
-              onValueChange={(v: GraphType) =>
-                notify(updateSeriesProperty(["graphType", v], series))
-              }
+              onValueChange={handleGraphTypeChange}
               className="mt-2 pl-2"
             >
               {Object.entries(GRAPH_TYPES).map(([graphType, graphTypeText]) => (

--- a/src/components/parts/series-config-card.component.tsx
+++ b/src/components/parts/series-config-card.component.tsx
@@ -174,7 +174,7 @@ export function SeriesConfigCard({ series, notify, onRemoveClick }: Props) {
           <div>
             <span>グラフ種類</span>
             <RadioGroup
-              defaultValue={series.graphType}
+              value={series.graphType}
               onValueChange={(v: GraphType) =>
                 notify(updateSeriesProperty(["graphType", v], series))
               }


### PR DESCRIPTION
表題に加えて、積み上げ棒グラフで属性を選択した後に、100%積み上げ棒グラフ等のグラフを選択したときに、もう一度属性を選択する必要をなくしました